### PR TITLE
Added new filter to manipulate incoming data

### DIFF
--- a/src/webhook/class-listener.php
+++ b/src/webhook/class-listener.php
@@ -90,7 +90,7 @@ class Listener {
 
 		$log = $this->get_log();
 		define( 'MC4WP_SYNC_DOING_WEBHOOK', true );
-		
+
 		// no parameters = MailChimp webhook validator
 		if( empty( $_POST['data'] ) || empty( $_POST['type'] ) ) {
 			echo "Listening..";
@@ -161,6 +161,9 @@ class Listener {
 			);
 			$updated = true;
 		}
+
+		// manipulate incoming data to match expected format.
+		$data = apply_filters( 'mailchimp_sync_webhook_data', $data, $user, $type );
 
 		// update WP user with data (use reversed field map)
 		// loop through mapping rules


### PR DESCRIPTION
Added a new filter to manipulate incoming data from the webhook before it is written to the db. We needed this as the data format stored in Mailchimp doesn't match the one in WordPress. 

We could have used the action triggered at the end but it is much cleaner to filter the data in the first place than first writing the data to the db and then looping over the data to clean it up.