### PR TITLE
Fixes #80: Updating subscriber addresses in MailChimp.

### DIFF
--- a/src/class-list-syncer.php
+++ b/src/class-list-syncer.php
@@ -67,6 +67,32 @@ class ListSynchronizer {
 	}
 	
 	/**
+	 * Handles updating a subscriber's email address for sync.
+	 *
+	 * @param int $user_id
+	 * @param null|string $old_email_address
+	 * @return boolean
+	 */
+	public function update_user ( $user_id, $old_email_address = null ) {
+
+		try {
+			$user = $this->users->user( $user_id );
+		} catch( Exception $e ) {
+			return false;
+		}
+
+		// Update the email address,
+		if ( null !== $old_email_address ) {
+			$user_subscriber = $this->get_user_subscriber();
+			$user_subscriber->update_email( $user->ID, $old_email_address );
+		}
+
+		// Then just fallback to what we used to do.
+		return $this->handle_user( $user_id );
+
+	}
+
+	/**
 	 * Handle
 	 *
 	 * @param int $user_id

--- a/src/class-user-subscriber.php
+++ b/src/class-user-subscriber.php
@@ -98,6 +98,15 @@ class UserSubscriber {
 
     /**
      * @param int $user_id
+     * @param string $old_email
+     */
+    public function update_email( $user_id, $old_email ) {
+        $user = $this->users->user( $user_id );
+        $this->mailchimp->api->update_list_member( $this->list_id, $old_email, array( 'email_address' => $user->user_email ) );
+    }
+
+    /**
+     * @param int $user_id
      * @param string $email_address
      * @param string $subscriber_uid        (optional)
      * @param null $send_goodbye            (unused)

--- a/src/class-user-subscriber.php
+++ b/src/class-user-subscriber.php
@@ -142,7 +142,7 @@ class UserSubscriber {
      */
     public function update_email( $user_id, $old_email ) {
         $user = $this->users->user( $user_id );
-        $this->mailchimp->api->update_list_member( $this->list_id, $old_email, array( 'email_address' => $user->user_email ) );
+        $this->api->update_list_member( $this->list_id, $old_email, array( 'email_address' => $user->user_email ) );
     }
 
     /**


### PR DESCRIPTION
I'm still wrapping my head around MailChimp for WordPress's internal class structure so this commit is pretty conservative. This commit does the following:

1. When a user updates their profile, the plugin now explicitly checks to see if their email address has changed.
1. If it has, the plugin makes a single, small MailChimp API request to update the old email address and set it to the new address without changing the subscriber ID, unsubscribing, or resubscribing anyone.
1. For the sake of compatibility and my own ignorance, the plugin then behaves *exactly* the same way as it does before, by calling the same method it would have before, but using the newly updated email address.

This should be safe but is possibly not the most elegant solution. Please advise on any changes you'd like to see before merge. This fix is a high-priority issue for an important person in my life, which is why I took it upon myself to send you a pull request. I can prioritize improving this PR with some guidance from you.

This commit also normalizes some mixed tabs and spaces in some files, just for consistency's sake.